### PR TITLE
add: IOB2 reordering and parsing improvements

### DIFF
--- a/propn-ner-comparator/README.md
+++ b/propn-ner-comparator/README.md
@@ -21,3 +21,13 @@ Dependencies as the first one and `.iob2` from UniversalNER as the second one.
 To find the coverage between the two files one can run something like
 
     $ poetry run python parse.py data/UD_Chinese-PUD/zh_pud-ud-test.conllu data/UNER_Chinese-PUD/zh_pud-ud-test.iob2
+
+The sentences inside  UniversalNER `.iob2` files tend to be ordered differently
+than the `.conllu` files provided by Universal Dependencies. It is hence
+preferable to reorder the original file first by running the `reorder.py`
+script.
+
+To produce a new, reordered IOB2 file, in which the sentences are ordered in
+the same way as in the `.conllu` file, one can run the following command:
+
+    $ poetry run python reorder.py data/UD_Swedish-PUD/sv_pud-ud-test.conllu data/UNER_Swedish-PUD/sv_pud-ud-test.iob2 data/UNER_Swedish-PUD/sv_pud-ud-test_reorder.iob2

--- a/propn-ner-comparator/parse.py
+++ b/propn-ner-comparator/parse.py
@@ -3,10 +3,19 @@ from conllu import parse
 from pathlib import Path
 from sklearn.metrics import confusion_matrix, f1_score
 
+
+def remove_tokens_with_non_int_ids(sentences: list):
+    for sentence in sentences:
+        yield sentence.filter(id=lambda x: type(x) is int)
+
+
 def parse_compare(conllu_file: Path, iob_file: Path):
     
     conllu_sentences = parse(conllu_file.read_text())
     iob_sentences = parse(iob_file.read_text())
+
+    conllu_sentences = remove_tokens_with_non_int_ids(conllu_sentences)
+    iob_sentences = remove_tokens_with_non_int_ids(iob_sentences)
 
     n_tokens = 0
     n_misaligned = 0

--- a/propn-ner-comparator/reorder.py
+++ b/propn-ner-comparator/reorder.py
@@ -1,0 +1,42 @@
+import typer
+from conllu import parse
+from pathlib import Path
+import hashlib
+
+def remove_tokens_with_non_int_ids(sentences: list):
+    for sentence in sentences:
+        yield sentence.filter(id=lambda x: type(x) is int)
+
+def hash(input: str):
+    return hashlib.sha3_512(input.encode()).digest()
+
+def sentence_to_text(sent):
+    return ' '.join(map(lambda x: x['form'].lower(), sent))
+
+def sentence_to_hash(sent):
+    return hash(sentence_to_text(sent))
+
+def reorder(conllu_file: Path, iob_file: Path, ordered_file: Path):
+
+    conllu_sentences = parse(conllu_file.read_text())
+    iob_sentences = parse(iob_file.read_text())
+
+    conllu_sentences = remove_tokens_with_non_int_ids(conllu_sentences)
+    iob_sentences = remove_tokens_with_non_int_ids(iob_sentences)
+
+    id2iob = {sentence_to_hash(s): s for s in iob_sentences}
+
+    ordered_sentences = []
+
+    for s in conllu_sentences:
+        h = sentence_to_hash(s)
+        try:
+            ordered_sentences.append(id2iob[h].serialize())
+        except KeyError:
+            print(s, sentence_to_text(s))
+
+    ordered_file.write_text('\n\n'.join(ordered_sentences))
+
+
+if __name__ == "__main__":
+    typer.run(reorder)


### PR DESCRIPTION
* Add a script that allows for the IOB2 to be reordered into the same order as the `.conllu` file on the sentence level.

* Ensure the `parse.py` script ignores non-integer tokens, that is tokens like `7.1` or `2-3`.